### PR TITLE
fix: macOS/Linux compatibility for browser_open, run_command, and insert_after

### DIFF
--- a/src/gateway/browser-tools.ts
+++ b/src/gateway/browser-tools.ts
@@ -38,9 +38,15 @@ const sessions: Map<string, BrowserSession> = new Map();
 let playwrightModule: any = null;
 let playwrightChecked = false;
 
+const os = require('os');
+const PLAYWRIGHT_BROWSERS_PATH = process.env.PLAYWRIGHT_BROWSERS_PATH
+  || require('path').join(os.homedir(), '.playwright-browsers');
+
 async function getPW(): Promise<any | null> {
   if (playwrightChecked) return playwrightModule;
   playwrightChecked = true;
+  // Set PLAYWRIGHT_BROWSERS_PATH before Playwright loads so it can find its bundled Chromium
+  process.env.PLAYWRIGHT_BROWSERS_PATH = PLAYWRIGHT_BROWSERS_PATH;
   try {
     playwrightModule = await (Function('return import("playwright")')() as Promise<any>);
     return playwrightModule;
@@ -82,6 +88,20 @@ async function getOrCreateSession(sessionId: string): Promise<BrowserSession> {
 
     const chromePaths = [
       process.env.CHROME_PATH,
+      // Playwright bundled Chromium (installed via `npx playwright install chromium`)
+      `${PLAYWRIGHT_BROWSERS_PATH}/chromium-1208/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`,
+      `${PLAYWRIGHT_BROWSERS_PATH}/chromium-1208/chrome-linux/chrome`,
+      `${PLAYWRIGHT_BROWSERS_PATH}/chromium-1208/chrome-win/chrome.exe`,
+      // macOS system Chrome
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      '/Applications/Chromium.app/Contents/MacOS/Chromium',
+      `${process.env.HOME}/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`,
+      // Linux
+      '/usr/bin/google-chrome',
+      '/usr/bin/google-chrome-stable',
+      '/usr/bin/chromium-browser',
+      '/usr/bin/chromium',
+      // Windows
       'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
       'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
       `${process.env.LOCALAPPDATA}\\Google\\Chrome\\Application\\chrome.exe`,
@@ -89,41 +109,46 @@ async function getOrCreateSession(sessionId: string): Promise<BrowserSession> {
 
     const fs = await import('fs');
     const chromePath = chromePaths.find(p => fs.existsSync(p));
-    if (!chromePath) throw new Error('Chrome not found. Set CHROME_PATH env var.');
 
-    const path = await import('path');
-    const os = await import('os');
-    const profileDir = process.env.CHROME_PROFILE
-      || path.join(os.homedir(), '.localclaw', 'chrome-debug-profile');
+    if (chromePath) {
+      // System Chrome found — launch with CDP so we can connect
+      const path = await import('path');
+      const os = await import('os');
+      const profileDir = process.env.CHROME_PROFILE
+        || path.join(os.homedir(), '.localclaw', 'chrome-debug-profile');
 
-    // Ensure profile dir exists
-    if (!fs.existsSync(profileDir)) fs.mkdirSync(profileDir, { recursive: true });
+      if (!fs.existsSync(profileDir)) fs.mkdirSync(profileDir, { recursive: true });
 
-    const { spawn } = await import('child_process');
-    spawn(chromePath, [
-      `--remote-debugging-port=${debugPort}`,
-      `--user-data-dir=${profileDir}`,
-      '--no-first-run',
-      '--no-default-browser-check',
-      '--disable-background-timer-throttling',
-    ], { detached: true, stdio: 'ignore' }).unref();
+      const { spawn } = await import('child_process');
+      spawn(chromePath, [
+        `--remote-debugging-port=${debugPort}`,
+        `--user-data-dir=${profileDir}`,
+        '--no-first-run',
+        '--no-default-browser-check',
+        '--disable-background-timer-throttling',
+      ], { detached: true, stdio: 'ignore' }).unref();
 
-    console.log(`[Browser] Chrome profile: ${profileDir} (log in once, saved forever)`);
+      console.log(`[Browser] Chrome profile: ${profileDir} (log in once, saved forever)`);
 
-    // Wait for Chrome to start
-    let connected = false;
-    for (let i = 0; i < 30; i++) {
-      await new Promise(r => setTimeout(r, 500));
-      if (await isPortOpen(debugPort)) {
-        try {
-          browser = await pw.chromium.connectOverCDP(`http://localhost:${debugPort}`);
-          connected = true;
-          break;
-        } catch { /* retry */ }
+      let connected = false;
+      for (let i = 0; i < 30; i++) {
+        await new Promise(r => setTimeout(r, 500));
+        if (await isPortOpen(debugPort)) {
+          try {
+            browser = await pw.chromium.connectOverCDP(`http://localhost:${debugPort}`);
+            connected = true;
+            break;
+          } catch { /* retry */ }
+        }
       }
+      if (!connected) throw new Error(`Chrome launched but did not respond on port ${debugPort} after 15s.`);
+      console.log(`[Browser] Launched and connected to Chrome on port ${debugPort}`);
+    } else {
+      // No system Chrome — use Playwright's bundled Chromium directly
+      console.log('[Browser] No system Chrome found. Launching Playwright bundled Chromium...');
+      browser = await pw.chromium.launch({ headless: false, args: ['--no-first-run', '--no-default-browser-check'] });
+      console.log('[Browser] Playwright Chromium launched.');
     }
-    if (!connected) throw new Error(`Chrome launched but did not respond on port ${debugPort} after 15s. Close any existing Chrome windows and try again.`);
-    console.log(`[Browser] Launched and connected to Chrome on port ${debugPort}`);
   }
 
   // Get or create a context, then a page

--- a/src/gateway/server-v2.ts
+++ b/src/gateway/server-v2.ts
@@ -35,8 +35,32 @@ const MAX_TOOL_ROUNDS = 12;
 // Active tasks (keyed by session)
 const activeTasks: Map<string, TaskState> = new Map();
 
-// Safe commands allowlist for run_command
-const SAFE_COMMANDS: Record<string, string> = {
+// Safe commands allowlist for run_command — platform-aware
+const isMac = process.platform === 'darwin';
+const isLinux = process.platform === 'linux';
+const SAFE_COMMANDS: Record<string, string> = isMac ? {
+  'chrome': 'open -a "Google Chrome"',
+  'browser': 'open -a "Google Chrome"',
+  'firefox': 'open -a Firefox',
+  'edge': 'open -a "Microsoft Edge"',
+  'notepad': 'open -a TextEdit',
+  'calc': 'open -a Calculator',
+  'calculator': 'open -a Calculator',
+  'explorer': 'open .',
+  'finder': 'open .',
+  'terminal': 'open -a Terminal',
+  'cmd': 'open -a Terminal',
+} : isLinux ? {
+  'chrome': 'google-chrome',
+  'browser': 'xdg-open https://google.com',
+  'firefox': 'firefox',
+  'notepad': 'gedit',
+  'calc': 'gnome-calculator',
+  'calculator': 'gnome-calculator',
+  'explorer': 'xdg-open .',
+  'terminal': 'x-terminal-emulator',
+  'cmd': 'x-terminal-emulator',
+} : {
   'chrome': 'start chrome',
   'browser': 'start chrome',
   'firefox': 'start firefox',
@@ -578,7 +602,7 @@ async function executeTool(name: string, args: any, workspacePath: string, sessi
         if (!fs.existsSync(filePath)) return { name, args, result: `"${filename}" not found`, error: true };
         const lines = fs.readFileSync(filePath, 'utf-8').split('\n');
         const insertAt = Math.min(afterLine, lines.length);
-        lines.splice(insertAt, 0, ...content.split('\\n'));
+        lines.splice(insertAt, 0, ...content.split('\n'));
         fs.writeFileSync(filePath, lines.join('\n'), 'utf-8');
         return { name, args, result: `${filename}: inserted after line ${afterLine} (now ${lines.length} lines)`, error: false };
       }
@@ -649,17 +673,17 @@ async function executeTool(name: string, args: any, workspacePath: string, sessi
           let url = parts.slice(1).join(' ');
           // Add https:// if missing
           if (url && !url.startsWith('http')) url = 'https://' + url;
-          const appCmd = SAFE_COMMANDS[app] || `start chrome`;
-          execCmd = `${appCmd} ${url}`;
+          const appCmd = SAFE_COMMANDS[app] || (isMac ? 'open' : 'start chrome');
+          execCmd = isMac ? `open "${url}"` : `${appCmd} ${url}`;
         }
         // 3. Plain URL → open in default browser
         else if (/^(https?:\/\/|www\.)/.test(cmd)) {
           const url = cmd.startsWith('www.') ? 'https://' + rawCmd : rawCmd;
-          execCmd = `start "" "${url}"`;
+          execCmd = isMac ? `open "${url}"` : isLinux ? `xdg-open "${url}"` : `start "" "${url}"`;
         }
         // 4. Bare domain like "youtube.com" → open in browser
         else if (/^[a-z0-9-]+\.[a-z]{2,}/.test(cmd) && !cmd.includes(' ')) {
-          execCmd = `start "" "https://${rawCmd}"`;
+          execCmd = isMac ? `open "https://${rawCmd}"` : isLinux ? `xdg-open "https://${rawCmd}"` : `start "" "https://${rawCmd}"`;
         }
         // 5. "code <path>" → VS Code
         else if (cmd.startsWith('code ')) {


### PR DESCRIPTION
## Summary

Three bugs prevent SmallClaw from working on macOS and Linux. Discovered while setting up the project on macOS 15 (Apple Silicon) with `qwen2.5-coder:32b`.

---

## Bug 1 — `browser_open` crashes with "Chrome not found" on macOS/Linux

**File:** `src/gateway/browser-tools.ts`

The `chromePaths` array only contained Windows paths. On macOS/Linux, `browser_open` always threw:
```
ERROR: Chrome not found. Set CHROME_PATH env var.
```

**Fix:**
- Add macOS path (`/Applications/Google Chrome.app/...`) and Linux paths (`/usr/bin/google-chrome` etc.)
- Add Playwright bundled Chromium paths (`~/.playwright-browsers/`) — works immediately after `npx playwright install chromium` with no system Chrome needed
- Set `PLAYWRIGHT_BROWSERS_PATH` env var before Playwright loads so it resolves the bundled binary correctly
- Fall back to `pw.chromium.launch()` directly when no system Chrome is found, instead of throwing

---

## Bug 2 — `run_command` / `SAFE_COMMANDS` are Windows-only

**File:** `src/gateway/server-v2.ts`

All `SAFE_COMMANDS` entries use Windows `start` syntax (`start chrome`, `start notepad`) and URL opening uses `start "" "url"` — none of which exist on macOS or Linux.

**Fix:**
- Platform detection at startup (`isMac` / `isLinux` flags)
- macOS: `open -a "Google Chrome"`, `open -a Calculator`, `open -a TextEdit`, `open -a Terminal`, etc.
- Linux: `xdg-open`, native app names
- URL opening: `open "url"` on macOS, `xdg-open "url"` on Linux, original `start` on Windows

---

## Bug 3 — `insert_after` splits on literal `\n` string instead of newline character

**File:** `src/gateway/server-v2.ts`, `insert_after` case

The bug: `content.split('\\n')` (two-character backslash-n) never actually splits multi-line strings, so multi-line content is inserted as one long line, breaking file structure.

**Fix:** Change to `content.split('\n')` (actual newline character).

---

## Testing

Verified on macOS 15 (Apple Silicon), Ollama + `qwen2.5-coder:32b`, Node.js v22.
